### PR TITLE
EN-3701 Fix get token, add action output of updated refresh token

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,9 @@ inputs:
   refreshtoken:
     description: 'Atlassian OAuth2 refresh token received from authorisation process'
     required: true
+outputs:
+  updatedrefreshtoken:
+    description: 'New refresh token returned from the auth process'
 runs:
   using: 'docker'
   image: 'docker://ghcr.io/streeva/attach-document-confluence:v1.0.1'

--- a/attach_report_confluence.sh
+++ b/attach_report_confluence.sh
@@ -13,10 +13,14 @@ CLIENTID=$6
 CLIENTSECRET=$7
 REFRESH_TOKEN=$8
 
-ACCESS_TOKEN=$(curl -s --request POST \
+TOKEN_RESPONSE=$(curl -s --request POST \
   --url 'https://auth.atlassian.com/oauth/token' \
   --header 'Content-Type: application/json' \
-  --data '{ "grant_type": "refresh_token", "client_id": "'$CLIENTID'", "client_secret": "'$CLIENTSECRET'", "refresh_token": "'$REFRESH_TOKEN'" }' | jq -r .access_token)
+  --data '{ "grant_type": "refresh_token", "client_id": "'$CLIENTID'", "client_secret": "'$CLIENTSECRET'", "refresh_token": "'$REFRESH_TOKEN'" }')
+
+ACCESS_TOKEN=$(echo $TOKEN_RESPONSE | jq -r .access_token)
+REFRESH_TOKEN=$(echo $TOKEN_RESPONSE | jq -r .refresh_token)
+echo "::set-output name=updatedrefreshtoken::$REFRESH_TOKEN"
 
 CQL='cql=title="'$PAGEHEADING'" and Space='$SPACEKEY
 SEARCHRESULTS=$(curl -s -G --url 'https://'$DOMAIN'.atlassian.net/wiki/rest/api/content/search' \

--- a/get_access_token.sh
+++ b/get_access_token.sh
@@ -21,7 +21,7 @@ urlencode() {
 }
 
 echo "Copy the following URL and visit using your browser:"
-echo "https://auth.atlassian.com/authorize?audience=api.atlassian.com&client_id=$CLIENTID&scope=read%3Aconfluence-content.summary%20write%3Aconfluence-file%20offline_access&redirect_uri=$(urlencode $REDIRECTURL)%2F153d3ee9-701f-4ce7-b271-79d03d5ee0d3&state=1234&response_type=code&prompt=consent"
+echo "https://auth.atlassian.com/authorize?audience=api.atlassian.com&client_id=$CLIENTID&scope=read%3Aconfluence-content.summary%20write%3Aconfluence-file%20offline_access&redirect_uri=$(urlencode $REDIRECTURL)&state=1234&response_type=code&prompt=consent"
 echo "Follow the auth flow to grant your app the access it needs, and when redirected copy the parameter value for code and enter it below"
 
 read -p "Enter code: "  CODE


### PR DESCRIPTION
- Add action output so that when the refresh_token is udpated (which is every time you refresh based on the new rules) the new token is available to a subsequent set-secret action as required.
- Fix an issue where get_access_token.sh was constructing the URL to visit to obtain the first refresh_token incorrectly.